### PR TITLE
Update Plugin.Permissions to 3.0.0.12

### DIFF
--- a/Plugin.Geofencing/Plugin.Geofencing.csproj
+++ b/Plugin.Geofencing/Plugin.Geofencing.csproj
@@ -37,7 +37,7 @@
         <Compile Remove="Platforms\**\*.cs" />
         <Compile Include="Platforms\Shared\**\*.cs" />
         <None Include="Platforms\**\*.cs" />
-        <PackageReference Include="Plugin.Permissions" Version="2.2.1" />
+        <PackageReference Include="Plugin.Permissions" Version="3.0.0.12" /> 
         <PackageReference Include="MSBuild.Sdk.Extras" Version="1.4.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Samples/Samples.Droid/MainApplication.cs
+++ b/Samples/Samples.Droid/MainApplication.cs
@@ -21,6 +21,8 @@ namespace Samples.Droid
             base.OnCreate();
             RegisterActivityLifecycleCallbacks(this);
             //A great place to initialize Xamarin.Insights and Dependency Services!
+
+            CrossCurrentActivity.Current.Init(this);
         }
 
         public override void OnTerminate()
@@ -31,7 +33,7 @@ namespace Samples.Droid
 
         public void OnActivityCreated(Activity activity, Bundle savedInstanceState)
         {
-            CrossCurrentActivity.Current.Activity = activity;
+            
         }
 
         public void OnActivityDestroyed(Activity activity)
@@ -44,7 +46,7 @@ namespace Samples.Droid
 
         public void OnActivityResumed(Activity activity)
         {
-            CrossCurrentActivity.Current.Activity = activity;
+          
         }
 
         public void OnActivitySaveInstanceState(Activity activity, Bundle outState)
@@ -53,7 +55,6 @@ namespace Samples.Droid
 
         public void OnActivityStarted(Activity activity)
         {
-            CrossCurrentActivity.Current.Activity = activity;
         }
 
         public void OnActivityStopped(Activity activity)

--- a/Samples/Samples.Droid/Samples.Droid.csproj
+++ b/Samples/Samples.Droid/Samples.Droid.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Plugin.Permissions">
-      <Version>2.2.1</Version>
+      <Version>3.0.0.12</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>2.5.1.444934</Version>

--- a/Samples/Samples.Uwp/Samples.Uwp.csproj
+++ b/Samples/Samples.Uwp/Samples.Uwp.csproj
@@ -93,7 +93,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.8" />
     <PackageReference Include="Plugin.Permissions">
-      <Version>2.2.1</Version>
+      <Version>3.0.0.12</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="2.5.1.444934" />
   </ItemGroup>

--- a/Samples/Samples.iOS/Samples.iOS.csproj
+++ b/Samples/Samples.iOS/Samples.iOS.csproj
@@ -138,7 +138,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Plugin.Permissions">
-      <Version>2.2.1</Version>
+      <Version>3.0.0.12</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Build.Download">
       <Version>0.4.11</Version>

--- a/Samples/Samples/Samples.csproj
+++ b/Samples/Samples/Samples.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Acr.Core" Version="2.0.2" />
     <PackageReference Include="Acr.UserDialogs" Version="7.0.1" />
-    <PackageReference Include="Plugin.Permissions" Version="2.2.1" />
+    <PackageReference Include="Plugin.Permissions" Version="3.0.0.12" />
     <PackageReference Include="ReactiveUI" Version="8.0.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.4.118" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.1.444934" />


### PR DESCRIPTION
Updated to latest Plugin.Permissions, in order to make it compatible with other xamarin plugins, like 
[Plugin.GeoLocator](https://github.com/jamesmontemagno/GeolocatorPlugin)

Currently using the latest versions of both plugins causes this build-error:

```
 error XA2002: Can not resolve reference: `Plugin.Permissions.Abstractions`, referenced by `Plugin.Geofencing`. Please add a NuGet package or assembly reference for `Plugin.Permissions.Abstractions`, or remove the reference to `Plugin.Geofencing`.
```
